### PR TITLE
refactor: rename medicine explanation API method

### DIFF
--- a/frontend/lib/screens/add_medicine_screen.dart
+++ b/frontend/lib/screens/add_medicine_screen.dart
@@ -34,7 +34,7 @@ class _AddMedicineScreenState extends State<AddMedicineScreen> {
       dosage: _dosageController.text,
       time: _timeController.text,
     );
-    final explanation = await ApiService.explainMedicine(medicine.name);
+    final explanation = await ApiService.getMedicineExplanation(medicine.name);
     setState(() => _loading = false);
     if (!mounted) return;
     Navigator.push(

--- a/frontend/lib/services/api_service.dart
+++ b/frontend/lib/services/api_service.dart
@@ -3,7 +3,13 @@ import 'package:http/http.dart' as http;
 import '../utils/constants.dart';
 
 class ApiService {
-  static Future<String> explainMedicine(String medicine) async {
+  /// Fetches an AI generated explanation for [medicine].
+  ///
+  /// Renamed from `explainMedicine` to better reflect the intent of the
+  /// operation. Keeping the old signature would make the call site less
+  /// descriptive. This method posts the medicine name to the backend and
+  /// returns the explanation text on success.
+  static Future<String> getMedicineExplanation(String medicine) async {
     final url = Uri.parse('$baseUrl/gpt/explain');
     final response = await http.post(
       url,


### PR DESCRIPTION
## Summary
- rename `explainMedicine` to `getMedicineExplanation`
- update AddMedicineScreen to use new API method

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e43de29c4832cb686b7044d6b49d4